### PR TITLE
Feature/add mqtt setting overrides

### DIFF
--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -13,8 +13,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         "/home/myuser/key.pem".to_owned(),
         "endpoint.amazonaws.com".to_owned(),
         None,
-        None
-        );
+    );
 
     let (iot_core_client, eventloop_stuff) = AWSIoTAsyncClient::new(aws_settings).await?;
 

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -12,6 +12,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         "/home/myuser/cert.crt".to_owned(),
         "/home/myuser/key.pem".to_owned(),
         "endpoint.amazonaws.com".to_owned(),
+        None,
         None
         );
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -29,7 +29,6 @@ pub struct AWSIoTSettings {
         client_cert_path: String,
         client_key_path: String,
         aws_iot_endpoint: String,
-        last_will: Option<LastWill>,
         mqtt_options_overrides: Option<MQTTOptionsOverrides>
 }
 
@@ -40,7 +39,6 @@ impl AWSIoTSettings {
         client_cert_path: String,
         client_key_path: String,
         aws_iot_endpoint: String,
-        last_will: Option<LastWill>,
         mqtt_options_overrides: Option<MQTTOptionsOverrides>
     ) -> AWSIoTSettings {
         AWSIoTSettings {
@@ -49,7 +47,6 @@ impl AWSIoTSettings {
             client_cert_path,
             client_key_path,
             aws_iot_endpoint,
-            last_will,
             mqtt_options_overrides
         }
     }
@@ -98,13 +95,6 @@ fn get_mqtt_options(settings: AWSIoTSettings) -> Result<MqttOptions, error::AWSI
         if let Some(conn_timeout) = overrides.conn_timeout {
             mqtt_options.set_connection_timeout(conn_timeout);
         }
-    }
-
-    match settings.last_will {
-        Some(last_will) => {
-            mqtt_options.set_last_will(last_will);
-        },
-        None => (),
     }
 
     Ok(mqtt_options)

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,6 +7,22 @@ use crate::error;
 #[cfg(feature= "async")]
 use rumqttc::{EventLoop, AsyncClient};
 
+pub struct MQTTMaxPacketSize {
+    icoming_max_packet_size: usize,
+    outgoing_max_packet_size: usize,
+}
+
+pub struct MQTTOptionsOverrides {
+    pub clean_session: Option<bool>,
+    pub keep_alive: Option<Duration>,
+    pub max_packet_size: Option<MQTTMaxPacketSize>,
+    pub request_channel_capacity: Option<usize>,
+    pub pending_throttle: Option<Duration>,
+    pub inflight: Option<u16>,
+    pub last_will: Option<LastWill>,
+    pub conn_timeout: Option<u64>,
+}
+
 pub struct AWSIoTSettings {
         client_id: String,
         ca_path: String,
@@ -14,6 +30,7 @@ pub struct AWSIoTSettings {
         client_key_path: String,
         aws_iot_endpoint: String,
         last_will: Option<LastWill>,
+        mqtt_options_overrides: Option<MQTTOptionsOverrides>
 }
 
 impl AWSIoTSettings {
@@ -23,15 +40,18 @@ impl AWSIoTSettings {
         client_cert_path: String,
         client_key_path: String,
         aws_iot_endpoint: String,
-        last_will: Option<LastWill>) -> AWSIoTSettings {
-
+        last_will: Option<LastWill>,
+        mqtt_options_overrides: Option<MQTTOptionsOverrides>
+    ) -> AWSIoTSettings {
         AWSIoTSettings {
             client_id,
             ca_path,
             client_cert_path,
             client_key_path,
             aws_iot_endpoint,
-            last_will }
+            last_will,
+            mqtt_options_overrides
+        }
     }
 }
 
@@ -46,8 +66,39 @@ fn get_mqtt_options(settings: AWSIoTSettings) -> Result<MqttOptions, error::AWSI
         alpn: None,
         client_auth: Some((client_cert.to_vec(), Key::RSA(client_key.to_vec()))),
     });
+
     mqtt_options.set_transport(transport)
         .set_keep_alive(Duration::from_secs(10));
+
+    if let Some(overrides) = settings.mqtt_options_overrides {
+        if let Some(clean_session) = overrides.clean_session {
+            mqtt_options.set_clean_session(clean_session);
+        }
+        if let Some(keep_alive) = overrides.keep_alive {
+            mqtt_options.set_keep_alive(keep_alive);
+        }
+        if let Some(packet_size) = overrides.max_packet_size {
+            mqtt_options.set_max_packet_size(packet_size.icoming_max_packet_size, packet_size.outgoing_max_packet_size);
+        }
+        if let Some(request_channel_capacity) = overrides.request_channel_capacity {
+            mqtt_options.set_request_channel_capacity(request_channel_capacity);
+        }
+        if let Some(pending_throttle) = overrides.pending_throttle {
+            mqtt_options.set_pending_throttle(pending_throttle);
+        }
+        if let Some(inflight) = overrides.inflight {
+            mqtt_options.set_inflight(inflight);
+        }
+        if let Some(clean_session) = overrides.clean_session {
+            mqtt_options.set_clean_session(clean_session);
+        }
+        if let Some(last_will) = overrides.last_will {
+            mqtt_options.set_last_will(last_will);
+        }
+        if let Some(conn_timeout) = overrides.conn_timeout {
+            mqtt_options.set_connection_timeout(conn_timeout);
+        }
+    }
 
     match settings.last_will {
         Some(last_will) => {


### PR DESCRIPTION
In some cases, it is necessary to be able to override MQTT settings. Let me know if you know a better way of doing this.

Notice last_will property has now moved to mqtt_options_overrides property, thus this commit has breaking changes.