### PR TITLE
Prefer error propagation over unwraps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ async = ["tokio"]
 rumqttc = "0.15.0"
 serde_json = "1.0"
 mqtt4bytes = "0.1.6"
-tokio = { version = "1.14.0", features = ["rt-multi-thread", "sync", "macros", "net", "time"], optional = true }
+tokio = { version = "1.14.0", features = ["rt-multi-thread", "sync", "macros", "net", "time", "fs"], optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,8 @@ impl Display for AWSIoTError {
     }
 }
 
+impl std::error::Error for AWSIoTError {}
+
 impl From<std::io::Error> for AWSIoTError {
     fn from(_err: std::io::Error) -> AWSIoTError {
         AWSIoTError::IoError


### PR DESCRIPTION
Thanks for your work on this library!

There are a few places where we unwrap values rather than returning the Result to the callsite. In some cases this requires no change to the function signature, however in the case of `AWSIoTAsyncClient::new` it does, and therefore would constitute a breaking change. I think it's worth while though since we want to give the user the ability to handle the possibility that come certificates may not be available.

This PR also includes some formatting changes per rustfmt, and some slight refactoring to remove redundant calls to `to_vec`, switch to async file operations, etc. Feel free to disregard those at your discretion.