### PR TITLE
v0.8.0: normalize EC private keys to PKCS8 for TLS compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "logg
 tokio = { version = "1.43.0", features = ["rt-multi-thread", "sync", "fs"], optional = true }
 bus = { version = "2.4.0", optional = true }
 log = "0.4"
+base64 = "0.22"
 p256 = { version = "0.13", features = ["pem", "pkcs8"] }
 p384 = { version = "0.13", features = ["pem", "pkcs8"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "An easy to use SDK for connecting to AWS IoT Core."
 documentation = "https://docs.rs/aws-iot-device-sdk-rust"
 repository = "https://github.com/arnstein/aws-iot-device-sdk-rust"
 license = "MIT"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Arnstein Kleven <arnsteinkleven@gmail.com>"]
 edition = "2021"
 
@@ -33,3 +33,11 @@ p384 = { version = "0.13", features = ["pem", "pkcs8"] }
 default = ["async"]
 async = ["dep:tokio"]
 sync = ["dep:bus"]
+
+[[example]]
+name = "pubsub_async"
+required-features = ["async"]
+
+[[example]]
+name = "pubsub_sync"
+required-features = ["sync"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "An easy to use SDK for connecting to AWS IoT Core."
 documentation = "https://docs.rs/aws-iot-device-sdk-rust"
 repository = "https://github.com/arnstein/aws-iot-device-sdk-rust"
 license = "MIT"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Arnstein Kleven <arnsteinkleven@gmail.com>"]
 edition = "2021"
 
@@ -25,8 +25,19 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "logg
 tokio = { version = "1.43.0", features = ["rt-multi-thread", "sync", "fs"], optional = true }
 bus = { version = "2.4.0", optional = true }
 log = "0.4"
+base64 = "0.22"
+p256 = { version = "0.13", features = ["pem", "pkcs8"] }
+p384 = { version = "0.13", features = ["pem", "pkcs8"] }
 
 [features]
 default = ["async"]
 async = ["dep:tokio"]
 sync = ["dep:bus"]
+
+[[example]]
+name = "pubsub_async"
+required-features = ["async"]
+
+[[example]]
+name = "pubsub_sync"
+required-features = ["sync"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "logg
 tokio = { version = "1.43.0", features = ["rt-multi-thread", "sync", "fs"], optional = true }
 bus = { version = "2.4.0", optional = true }
 log = "0.4"
+p256 = { version = "0.13", features = ["pem", "pkcs8"] }
+p384 = { version = "0.13", features = ["pem", "pkcs8"] }
 
 [features]
 default = ["async"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "logg
 tokio = { version = "1.43.0", features = ["rt-multi-thread", "sync", "fs"], optional = true }
 bus = { version = "2.4.0", optional = true }
 log = "0.4"
-p256 = { version = "0.13", features = ["pem", "pkcs8", "sec1"] }
-p384 = { version = "0.13", features = ["pem", "pkcs8", "sec1"] }
+p256 = { version = "0.13", features = ["pem", "pkcs8"] }
+p384 = { version = "0.13", features = ["pem", "pkcs8"] }
 
 [features]
 default = ["async"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "logg
 tokio = { version = "1.43.0", features = ["rt-multi-thread", "sync", "fs"], optional = true }
 bus = { version = "2.4.0", optional = true }
 log = "0.4"
-p256 = { version = "0.13", features = ["pem", "pkcs8"] }
-p384 = { version = "0.13", features = ["pem", "pkcs8"] }
+p256 = { version = "0.13", features = ["pem", "pkcs8", "sec1"] }
+p384 = { version = "0.13", features = ["pem", "pkcs8", "sec1"] }
 
 [features]
 default = ["async"]

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ All fallible operations return `Result<_, AWSIoTError>`. The error type wraps th
 | `MQTTClientError` | Client operation failure such as publish/subscribe (wraps `rumqttc::ClientError`) |
 | `IoError` | File I/O error when reading certificates or keys |
 | `MutexError` | Mutex poisoning (sync client only) |
+| `KeyNormalizationError` | Private key normalization failed: non-UTF-8 key data, malformed PEM structure, invalid base64, unrecognized EC curve, or PKCS8 re-encoding failure |
 
 
 ## License

--- a/examples/pubsub_async.rs
+++ b/examples/pubsub_async.rs
@@ -47,10 +47,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     });
     let listen_thread = tokio::spawn(async move {
         async_event_loop_listener(eventloop_stuff).await.unwrap();
-        //iot_core_client.listen().await.unwrap();
     });
 
-    //iot_core_client.publish("topic".to_string(), QoS::AtMostOnce, "hey").await.unwrap();
     match tokio::join!(recv1_thread, recv2_thread, listen_thread) {
         (Ok(_), Ok(_), Ok(_)) => (),
         _ => panic!("Error in threads"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,8 @@ pub enum AWSIoTError {
     IoError(std::io::Error),
     /// A mutex was poisoned (sync client only).
     MutexError(String),
+    /// The private key could not be parsed or normalized.
+    KeyNormalizationError(String),
 }
 
 impl Display for AWSIoTError {
@@ -25,6 +27,9 @@ impl Display for AWSIoTError {
             }
             AWSIoTError::IoError(err) => write!(f, "Problem reading file: {err}"),
             AWSIoTError::MutexError(msg) => write!(f, "Mutex poisoned: {msg}"),
+            AWSIoTError::KeyNormalizationError(msg) => {
+                write!(f, "Key normalization failed: {msg}")
+            }
         }
     }
 }
@@ -36,6 +41,7 @@ impl std::error::Error for AWSIoTError {
             AWSIoTError::MQTTClientError(err) => Some(err),
             AWSIoTError::IoError(err) => Some(err),
             AWSIoTError::MutexError(_) => None,
+            AWSIoTError::KeyNormalizationError(_) => None,
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -62,6 +62,72 @@ impl AWSIoTSettings {
     }
 }
 
+fn normalize_key(key_pem: Vec<u8>) -> Vec<u8> {
+    let Ok(key_str) = std::str::from_utf8(&key_pem) else {
+        return key_pem;
+    };
+
+    // Handle SEC1 EC key (BEGIN EC PRIVATE KEY) — extract just the key block,
+    // skipping any leading EC PARAMETERS block that would confuse from_sec1_pem.
+    let begin_sec1 = "-----BEGIN EC PRIVATE KEY-----";
+    let end_sec1 = "-----END EC PRIVATE KEY-----";
+    if let Some(start) = key_str.find(begin_sec1) {
+        if let Some(end_offset) = key_str[start..].find(end_sec1) {
+            let ec_block = &key_str[start..start + end_offset + end_sec1.len()];
+            println!("aws-iot-sdk: SEC1 EC key detected, attempting PKCS8 conversion");
+            if let Ok(key) = p256::SecretKey::from_sec1_pem(ec_block) {
+                use p256::pkcs8::EncodePrivateKey;
+                if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
+                    println!("aws-iot-sdk: SEC1 key converted to PKCS8 (P-256)");
+                    return doc.as_bytes().to_vec();
+                }
+            }
+            if let Ok(key) = p384::SecretKey::from_sec1_pem(ec_block) {
+                use p384::pkcs8::EncodePrivateKey;
+                if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
+                    println!("aws-iot-sdk: SEC1 key converted to PKCS8 (P-384)");
+                    return doc.as_bytes().to_vec();
+                }
+            }
+            println!("aws-iot-sdk: SEC1 key conversion failed, returning original");
+            return key_pem;
+        }
+    }
+
+    // Handle PKCS8 EC key (BEGIN PRIVATE KEY) — re-encode through p256/p384 to
+    // normalize the structure (e.g. explicit curve params → named curve OID).
+    // If it's RSA or Ed25519 PKCS8, parsing will fail and we pass through unchanged.
+    let begin_pkcs8 = "-----BEGIN PRIVATE KEY-----";
+    let end_pkcs8 = "-----END PRIVATE KEY-----";
+    if let Some(start) = key_str.find(begin_pkcs8) {
+        if let Some(end_offset) = key_str[start..].find(end_pkcs8) {
+            let pkcs8_block = &key_str[start..start + end_offset + end_pkcs8.len()];
+            println!("aws-iot-sdk: PKCS8 key detected, attempting to normalize encoding");
+            {
+                use p256::pkcs8::{DecodePrivateKey, EncodePrivateKey};
+                if let Ok(key) = p256::SecretKey::from_pkcs8_pem(pkcs8_block) {
+                    if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
+                        println!("aws-iot-sdk: PKCS8 key normalized (P-256)");
+                        return doc.as_bytes().to_vec();
+                    }
+                }
+            }
+            {
+                use p384::pkcs8::{DecodePrivateKey, EncodePrivateKey};
+                if let Ok(key) = p384::SecretKey::from_pkcs8_pem(pkcs8_block) {
+                    if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
+                        println!("aws-iot-sdk: PKCS8 key normalized (P-384)");
+                        return doc.as_bytes().to_vec();
+                    }
+                }
+            }
+            println!("aws-iot-sdk: PKCS8 key is not P-256/P-384 (likely RSA), passing through");
+        }
+    }
+
+    key_pem
+}
+
 fn set_overrides(settings: AWSIoTSettings) -> MqttOptions {
     let port = settings
         .mqtt_options_overrides
@@ -118,7 +184,7 @@ pub(crate) async fn get_mqtt_options_async(
     let transport = (!transport_overrided).then_some({
         let ca = read(&settings.ca_path).await?;
         let client_cert = read(&settings.client_cert_path).await?;
-        let client_key = read(&settings.client_key_path).await?;
+        let client_key = normalize_key(read(&settings.client_key_path).await?);
 
         Transport::Tls(TlsConfiguration::Simple {
             ca,
@@ -149,7 +215,7 @@ pub(crate) fn get_mqtt_options(
     let transport = (!transport_overrided).then_some({
         let ca = read(&settings.ca_path)?;
         let client_cert = read(&settings.client_cert_path)?;
-        let client_key = read(&settings.client_key_path)?;
+        let client_key = normalize_key(read(&settings.client_key_path)?);
 
         Transport::Tls(TlsConfiguration::Simple {
             ca,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -69,17 +69,26 @@ fn normalize_key(key_pem: Vec<u8>) -> Vec<u8> {
     if !key_str.contains("BEGIN EC PRIVATE KEY") {
         return key_pem;
     }
+    log::info!("SEC1 EC key detected, converting to PKCS8");
     if let Ok(key) = p256::SecretKey::from_sec1_pem(key_str) {
         use p256::pkcs8::EncodePrivateKey;
         if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
+            log::info!("SEC1 key converted to PKCS8 (P-256)");
             return doc.as_bytes().to_vec();
         }
+        log::warn!("P-256 key parsed but PKCS8 encoding failed");
+    } else {
+        log::warn!("Key is not P-256, trying P-384");
     }
     if let Ok(key) = p384::SecretKey::from_sec1_pem(key_str) {
         use p384::pkcs8::EncodePrivateKey;
         if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
+            log::info!("SEC1 key converted to PKCS8 (P-384)");
             return doc.as_bytes().to_vec();
         }
+        log::warn!("P-384 key parsed but PKCS8 encoding failed");
+    } else {
+        log::warn!("Key is not P-384 either, returning original bytes (conversion failed)");
     }
     key_pem
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -66,30 +66,43 @@ fn normalize_key(key_pem: Vec<u8>) -> Vec<u8> {
     let Ok(key_str) = std::str::from_utf8(&key_pem) else {
         return key_pem;
     };
-    if !key_str.contains("BEGIN EC PRIVATE KEY") {
+
+    // Manually extract just the EC PRIVATE KEY block, skipping any leading
+    // EC PARAMETERS block that would cause from_sec1_pem to fail on the wrong label.
+    let begin = "-----BEGIN EC PRIVATE KEY-----";
+    let end = "-----END EC PRIVATE KEY-----";
+    let Some(start) = key_str.find(begin) else {
         return key_pem;
-    }
-    log::info!("SEC1 EC key detected, converting to PKCS8");
-    if let Ok(key) = p256::SecretKey::from_sec1_pem(key_str) {
+    };
+    let Some(end_offset) = key_str[start..].find(end) else {
+        return key_pem;
+    };
+    let ec_block = &key_str[start..start + end_offset + end.len()];
+
+    println!("aws-iot-sdk: SEC1 EC key detected, attempting PKCS8 conversion");
+
+    if let Ok(key) = p256::SecretKey::from_sec1_pem(ec_block) {
         use p256::pkcs8::EncodePrivateKey;
         if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
-            log::info!("SEC1 key converted to PKCS8 (P-256)");
+            println!("aws-iot-sdk: SEC1 key converted to PKCS8 (P-256)");
             return doc.as_bytes().to_vec();
         }
-        log::warn!("P-256 key parsed but PKCS8 encoding failed");
+        println!("aws-iot-sdk: P-256 parsed but PKCS8 encoding failed");
     } else {
-        log::warn!("Key is not P-256, trying P-384");
+        println!("aws-iot-sdk: Key is not P-256, trying P-384");
     }
-    if let Ok(key) = p384::SecretKey::from_sec1_pem(key_str) {
+
+    if let Ok(key) = p384::SecretKey::from_sec1_pem(ec_block) {
         use p384::pkcs8::EncodePrivateKey;
         if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
-            log::info!("SEC1 key converted to PKCS8 (P-384)");
+            println!("aws-iot-sdk: SEC1 key converted to PKCS8 (P-384)");
             return doc.as_bytes().to_vec();
         }
-        log::warn!("P-384 key parsed but PKCS8 encoding failed");
+        println!("aws-iot-sdk: P-384 parsed but PKCS8 encoding failed");
     } else {
-        log::warn!("Key is not P-384 either, returning original bytes (conversion failed)");
+        println!("aws-iot-sdk: Key is not P-256 or P-384, returning original bytes");
     }
+
     key_pem
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -62,6 +62,132 @@ impl AWSIoTSettings {
     }
 }
 
+fn normalize_key(key_pem: Vec<u8>) -> Result<Vec<u8>, error::AWSIoTError> {
+    let key_str = std::str::from_utf8(&key_pem).map_err(|e| {
+        error::AWSIoTError::KeyNormalizationError(format!("private key is not valid UTF-8: {e}"))
+    })?;
+
+    // Handle SEC1 EC key (BEGIN EC PRIVATE KEY) — extract just the key block,
+    // skipping any leading EC PARAMETERS block that would confuse from_sec1_pem.
+    let begin_sec1 = "-----BEGIN EC PRIVATE KEY-----";
+    let end_sec1 = "-----END EC PRIVATE KEY-----";
+    if let Some(start) = key_str.find(begin_sec1) {
+        let end_offset = key_str[start..].find(end_sec1).ok_or_else(|| {
+            error::AWSIoTError::KeyNormalizationError(
+                "SEC1 PEM has BEGIN marker but no END marker".into(),
+            )
+        })?;
+        let ec_block = &key_str[start..start + end_offset + end_sec1.len()];
+        if let Ok(key) = p256::SecretKey::from_sec1_pem(ec_block) {
+            use p256::pkcs8::EncodePrivateKey;
+            return key
+                .to_pkcs8_pem(Default::default())
+                .map(|doc| doc.as_bytes().to_vec())
+                .map_err(|e| {
+                    error::AWSIoTError::KeyNormalizationError(format!(
+                        "failed to re-encode SEC1 P-256 key as PKCS8: {e}"
+                    ))
+                });
+        }
+        if let Ok(key) = p384::SecretKey::from_sec1_pem(ec_block) {
+            use p384::pkcs8::EncodePrivateKey;
+            return key
+                .to_pkcs8_pem(Default::default())
+                .map(|doc| doc.as_bytes().to_vec())
+                .map_err(|e| {
+                    error::AWSIoTError::KeyNormalizationError(format!(
+                        "failed to re-encode SEC1 P-384 key as PKCS8: {e}"
+                    ))
+                });
+        }
+        return Err(error::AWSIoTError::KeyNormalizationError(
+            "SEC1 EC key is not a recognized curve (expected P-256 or P-384)".into(),
+        ));
+    }
+
+    // Handle PKCS8 EC key (BEGIN PRIVATE KEY) — re-encode through p256/p384 to
+    // normalize the structure (e.g. explicit curve params → named curve OID).
+    // If it's RSA or Ed25519 PKCS8, parsing will fail and we pass through unchanged.
+    let begin_pkcs8 = "-----BEGIN PRIVATE KEY-----";
+    let end_pkcs8 = "-----END PRIVATE KEY-----";
+    if let Some(start) = key_str.find(begin_pkcs8) {
+        let end_offset = key_str[start..].find(end_pkcs8).ok_or_else(|| {
+            error::AWSIoTError::KeyNormalizationError(
+                "PKCS8 PEM has BEGIN marker but no END marker".into(),
+            )
+        })?;
+        let pkcs8_block = &key_str[start..start + end_offset + end_pkcs8.len()];
+        {
+            use p256::pkcs8::{DecodePrivateKey, EncodePrivateKey};
+            if let Ok(key) = p256::SecretKey::from_pkcs8_pem(pkcs8_block) {
+                return key
+                    .to_pkcs8_pem(Default::default())
+                    .map(|doc| doc.as_bytes().to_vec())
+                    .map_err(|e| {
+                        error::AWSIoTError::KeyNormalizationError(format!(
+                            "failed to re-encode PKCS8 P-256 key: {e}"
+                        ))
+                    });
+            }
+        }
+        {
+            use p384::pkcs8::{DecodePrivateKey, EncodePrivateKey};
+            if let Ok(key) = p384::SecretKey::from_pkcs8_pem(pkcs8_block) {
+                return key
+                    .to_pkcs8_pem(Default::default())
+                    .map(|doc| doc.as_bytes().to_vec())
+                    .map_err(|e| {
+                        error::AWSIoTError::KeyNormalizationError(format!(
+                            "failed to re-encode PKCS8 P-384 key: {e}"
+                        ))
+                    });
+            }
+        }
+        // PKCS8 parsing failed — the PEM header might be lying and the DER
+        // content could actually be SEC1 (raw EC key).  Decode the base64
+        // payload and try SEC1 DER parsing as a last resort.
+        let base64_body: String = pkcs8_block
+            .lines()
+            .filter(|l| !l.starts_with("-----"))
+            .collect();
+        use base64::Engine;
+        let der = base64::engine::general_purpose::STANDARD
+            .decode(base64_body.trim())
+            .map_err(|e| {
+                error::AWSIoTError::KeyNormalizationError(format!(
+                    "PKCS8 PEM contains invalid base64: {e}"
+                ))
+            })?;
+        if let Ok(key) = p256::SecretKey::from_sec1_der(&der) {
+            use p256::pkcs8::EncodePrivateKey;
+            return key
+                .to_pkcs8_pem(Default::default())
+                .map(|doc| doc.as_bytes().to_vec())
+                .map_err(|e| {
+                    error::AWSIoTError::KeyNormalizationError(format!(
+                        "failed to re-encode mislabeled SEC1 P-256 key as PKCS8: {e}"
+                    ))
+                });
+        }
+        if let Ok(key) = p384::SecretKey::from_sec1_der(&der) {
+            use p384::pkcs8::EncodePrivateKey;
+            return key
+                .to_pkcs8_pem(Default::default())
+                .map(|doc| doc.as_bytes().to_vec())
+                .map_err(|e| {
+                    error::AWSIoTError::KeyNormalizationError(format!(
+                        "failed to re-encode mislabeled SEC1 P-384 key as PKCS8: {e}"
+                    ))
+                });
+        }
+        // Not an EC key we recognize — pass through unchanged (likely RSA or Ed25519).
+        return Ok(key_pem);
+    }
+
+    // No recognized PEM header — pass through unchanged (e.g. RSA PRIVATE KEY).
+    Ok(key_pem)
+}
+
 fn set_overrides(settings: AWSIoTSettings) -> MqttOptions {
     let port = settings
         .mqtt_options_overrides
@@ -118,7 +244,7 @@ pub(crate) async fn get_mqtt_options_async(
     let transport = (!transport_overrided).then_some({
         let ca = read(&settings.ca_path).await?;
         let client_cert = read(&settings.client_cert_path).await?;
-        let client_key = read(&settings.client_key_path).await?;
+        let client_key = normalize_key(read(&settings.client_key_path).await?)?;
 
         Transport::Tls(TlsConfiguration::Simple {
             ca,
@@ -149,7 +275,7 @@ pub(crate) fn get_mqtt_options(
     let transport = (!transport_overrided).then_some({
         let ca = read(&settings.ca_path)?;
         let client_cert = read(&settings.client_cert_path)?;
-        let client_key = read(&settings.client_key_path)?;
+        let client_key = normalize_key(read(&settings.client_key_path)?)?;
 
         Transport::Tls(TlsConfiguration::Simple {
             ca,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -67,40 +67,62 @@ fn normalize_key(key_pem: Vec<u8>) -> Vec<u8> {
         return key_pem;
     };
 
-    // Manually extract just the EC PRIVATE KEY block, skipping any leading
-    // EC PARAMETERS block that would cause from_sec1_pem to fail on the wrong label.
-    let begin = "-----BEGIN EC PRIVATE KEY-----";
-    let end = "-----END EC PRIVATE KEY-----";
-    let Some(start) = key_str.find(begin) else {
-        return key_pem;
-    };
-    let Some(end_offset) = key_str[start..].find(end) else {
-        return key_pem;
-    };
-    let ec_block = &key_str[start..start + end_offset + end.len()];
-
-    println!("aws-iot-sdk: SEC1 EC key detected, attempting PKCS8 conversion");
-
-    if let Ok(key) = p256::SecretKey::from_sec1_pem(ec_block) {
-        use p256::pkcs8::EncodePrivateKey;
-        if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
-            println!("aws-iot-sdk: SEC1 key converted to PKCS8 (P-256)");
-            return doc.as_bytes().to_vec();
+    // Handle SEC1 EC key (BEGIN EC PRIVATE KEY) — extract just the key block,
+    // skipping any leading EC PARAMETERS block that would confuse from_sec1_pem.
+    let begin_sec1 = "-----BEGIN EC PRIVATE KEY-----";
+    let end_sec1 = "-----END EC PRIVATE KEY-----";
+    if let Some(start) = key_str.find(begin_sec1) {
+        if let Some(end_offset) = key_str[start..].find(end_sec1) {
+            let ec_block = &key_str[start..start + end_offset + end_sec1.len()];
+            println!("aws-iot-sdk: SEC1 EC key detected, attempting PKCS8 conversion");
+            if let Ok(key) = p256::SecretKey::from_sec1_pem(ec_block) {
+                use p256::pkcs8::EncodePrivateKey;
+                if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
+                    println!("aws-iot-sdk: SEC1 key converted to PKCS8 (P-256)");
+                    return doc.as_bytes().to_vec();
+                }
+            }
+            if let Ok(key) = p384::SecretKey::from_sec1_pem(ec_block) {
+                use p384::pkcs8::EncodePrivateKey;
+                if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
+                    println!("aws-iot-sdk: SEC1 key converted to PKCS8 (P-384)");
+                    return doc.as_bytes().to_vec();
+                }
+            }
+            println!("aws-iot-sdk: SEC1 key conversion failed, returning original");
+            return key_pem;
         }
-        println!("aws-iot-sdk: P-256 parsed but PKCS8 encoding failed");
-    } else {
-        println!("aws-iot-sdk: Key is not P-256, trying P-384");
     }
 
-    if let Ok(key) = p384::SecretKey::from_sec1_pem(ec_block) {
-        use p384::pkcs8::EncodePrivateKey;
-        if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
-            println!("aws-iot-sdk: SEC1 key converted to PKCS8 (P-384)");
-            return doc.as_bytes().to_vec();
+    // Handle PKCS8 EC key (BEGIN PRIVATE KEY) — re-encode through p256/p384 to
+    // normalize the structure (e.g. explicit curve params → named curve OID).
+    // If it's RSA or Ed25519 PKCS8, parsing will fail and we pass through unchanged.
+    let begin_pkcs8 = "-----BEGIN PRIVATE KEY-----";
+    let end_pkcs8 = "-----END PRIVATE KEY-----";
+    if let Some(start) = key_str.find(begin_pkcs8) {
+        if let Some(end_offset) = key_str[start..].find(end_pkcs8) {
+            let pkcs8_block = &key_str[start..start + end_offset + end_pkcs8.len()];
+            println!("aws-iot-sdk: PKCS8 key detected, attempting to normalize encoding");
+            {
+                use p256::pkcs8::{DecodePrivateKey, EncodePrivateKey};
+                if let Ok(key) = p256::SecretKey::from_pkcs8_pem(pkcs8_block) {
+                    if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
+                        println!("aws-iot-sdk: PKCS8 key normalized (P-256)");
+                        return doc.as_bytes().to_vec();
+                    }
+                }
+            }
+            {
+                use p384::pkcs8::{DecodePrivateKey, EncodePrivateKey};
+                if let Ok(key) = p384::SecretKey::from_pkcs8_pem(pkcs8_block) {
+                    if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
+                        println!("aws-iot-sdk: PKCS8 key normalized (P-384)");
+                        return doc.as_bytes().to_vec();
+                    }
+                }
+            }
+            println!("aws-iot-sdk: PKCS8 key is not P-256/P-384 (likely RSA), passing through");
         }
-        println!("aws-iot-sdk: P-384 parsed but PKCS8 encoding failed");
-    } else {
-        println!("aws-iot-sdk: Key is not P-256 or P-384, returning original bytes");
     }
 
     key_pem

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -121,7 +121,32 @@ fn normalize_key(key_pem: Vec<u8>) -> Vec<u8> {
                     }
                 }
             }
-            println!("aws-iot-sdk: PKCS8 key is not P-256/P-384 (likely RSA), passing through");
+            // PKCS8 parsing failed — the PEM header might be lying and the DER
+            // content could actually be SEC1 (raw EC key).  Decode the base64
+            // payload and try SEC1 DER parsing as a last resort.
+            println!("aws-iot-sdk: PKCS8 parsing failed, trying SEC1 DER fallback");
+            let base64_body: String = pkcs8_block
+                .lines()
+                .filter(|l| !l.starts_with("-----"))
+                .collect();
+            use base64::Engine;
+            if let Ok(der) = base64::engine::general_purpose::STANDARD.decode(base64_body.trim()) {
+                if let Ok(key) = p256::SecretKey::from_sec1_der(&der) {
+                    use p256::pkcs8::EncodePrivateKey;
+                    if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
+                        println!("aws-iot-sdk: mislabeled SEC1 key converted to PKCS8 (P-256)");
+                        return doc.as_bytes().to_vec();
+                    }
+                }
+                if let Ok(key) = p384::SecretKey::from_sec1_der(&der) {
+                    use p384::pkcs8::EncodePrivateKey;
+                    if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
+                        println!("aws-iot-sdk: mislabeled SEC1 key converted to PKCS8 (P-384)");
+                        return doc.as_bytes().to_vec();
+                    }
+                }
+            }
+            println!("aws-iot-sdk: PKCS8 key is not P-256/P-384 EC (likely RSA), passing through");
         }
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -62,6 +62,28 @@ impl AWSIoTSettings {
     }
 }
 
+fn normalize_key(key_pem: Vec<u8>) -> Vec<u8> {
+    let Ok(key_str) = std::str::from_utf8(&key_pem) else {
+        return key_pem;
+    };
+    if !key_str.contains("BEGIN EC PRIVATE KEY") {
+        return key_pem;
+    }
+    if let Ok(key) = p256::SecretKey::from_sec1_pem(key_str) {
+        use p256::pkcs8::EncodePrivateKey;
+        if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
+            return doc.as_bytes().to_vec();
+        }
+    }
+    if let Ok(key) = p384::SecretKey::from_sec1_pem(key_str) {
+        use p384::pkcs8::EncodePrivateKey;
+        if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
+            return doc.as_bytes().to_vec();
+        }
+    }
+    key_pem
+}
+
 fn set_overrides(settings: AWSIoTSettings) -> MqttOptions {
     let port = settings
         .mqtt_options_overrides
@@ -118,7 +140,7 @@ pub(crate) async fn get_mqtt_options_async(
     let transport = (!transport_overrided).then_some({
         let ca = read(&settings.ca_path).await?;
         let client_cert = read(&settings.client_cert_path).await?;
-        let client_key = read(&settings.client_key_path).await?;
+        let client_key = normalize_key(read(&settings.client_key_path).await?);
 
         Transport::Tls(TlsConfiguration::Simple {
             ca,
@@ -149,7 +171,7 @@ pub(crate) fn get_mqtt_options(
     let transport = (!transport_overrided).then_some({
         let ca = read(&settings.ca_path)?;
         let client_cert = read(&settings.client_cert_path)?;
-        let client_key = read(&settings.client_key_path)?;
+        let client_key = normalize_key(read(&settings.client_key_path)?);
 
         Transport::Tls(TlsConfiguration::Simple {
             ca,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -62,36 +62,47 @@ impl AWSIoTSettings {
     }
 }
 
-fn normalize_key(key_pem: Vec<u8>) -> Vec<u8> {
-    let Ok(key_str) = std::str::from_utf8(&key_pem) else {
-        return key_pem;
-    };
+fn normalize_key(key_pem: Vec<u8>) -> Result<Vec<u8>, error::AWSIoTError> {
+    let key_str = std::str::from_utf8(&key_pem).map_err(|e| {
+        error::AWSIoTError::KeyNormalizationError(format!("private key is not valid UTF-8: {e}"))
+    })?;
 
     // Handle SEC1 EC key (BEGIN EC PRIVATE KEY) — extract just the key block,
     // skipping any leading EC PARAMETERS block that would confuse from_sec1_pem.
     let begin_sec1 = "-----BEGIN EC PRIVATE KEY-----";
     let end_sec1 = "-----END EC PRIVATE KEY-----";
     if let Some(start) = key_str.find(begin_sec1) {
-        if let Some(end_offset) = key_str[start..].find(end_sec1) {
-            let ec_block = &key_str[start..start + end_offset + end_sec1.len()];
-            println!("aws-iot-sdk: SEC1 EC key detected, attempting PKCS8 conversion");
-            if let Ok(key) = p256::SecretKey::from_sec1_pem(ec_block) {
-                use p256::pkcs8::EncodePrivateKey;
-                if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
-                    println!("aws-iot-sdk: SEC1 key converted to PKCS8 (P-256)");
-                    return doc.as_bytes().to_vec();
-                }
-            }
-            if let Ok(key) = p384::SecretKey::from_sec1_pem(ec_block) {
-                use p384::pkcs8::EncodePrivateKey;
-                if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
-                    println!("aws-iot-sdk: SEC1 key converted to PKCS8 (P-384)");
-                    return doc.as_bytes().to_vec();
-                }
-            }
-            println!("aws-iot-sdk: SEC1 key conversion failed, returning original");
-            return key_pem;
+        let end_offset = key_str[start..].find(end_sec1).ok_or_else(|| {
+            error::AWSIoTError::KeyNormalizationError(
+                "SEC1 PEM has BEGIN marker but no END marker".into(),
+            )
+        })?;
+        let ec_block = &key_str[start..start + end_offset + end_sec1.len()];
+        if let Ok(key) = p256::SecretKey::from_sec1_pem(ec_block) {
+            use p256::pkcs8::EncodePrivateKey;
+            return key
+                .to_pkcs8_pem(Default::default())
+                .map(|doc| doc.as_bytes().to_vec())
+                .map_err(|e| {
+                    error::AWSIoTError::KeyNormalizationError(format!(
+                        "failed to re-encode SEC1 P-256 key as PKCS8: {e}"
+                    ))
+                });
         }
+        if let Ok(key) = p384::SecretKey::from_sec1_pem(ec_block) {
+            use p384::pkcs8::EncodePrivateKey;
+            return key
+                .to_pkcs8_pem(Default::default())
+                .map(|doc| doc.as_bytes().to_vec())
+                .map_err(|e| {
+                    error::AWSIoTError::KeyNormalizationError(format!(
+                        "failed to re-encode SEC1 P-384 key as PKCS8: {e}"
+                    ))
+                });
+        }
+        return Err(error::AWSIoTError::KeyNormalizationError(
+            "SEC1 EC key is not a recognized curve (expected P-256 or P-384)".into(),
+        ));
     }
 
     // Handle PKCS8 EC key (BEGIN PRIVATE KEY) — re-encode through p256/p384 to
@@ -100,57 +111,81 @@ fn normalize_key(key_pem: Vec<u8>) -> Vec<u8> {
     let begin_pkcs8 = "-----BEGIN PRIVATE KEY-----";
     let end_pkcs8 = "-----END PRIVATE KEY-----";
     if let Some(start) = key_str.find(begin_pkcs8) {
-        if let Some(end_offset) = key_str[start..].find(end_pkcs8) {
-            let pkcs8_block = &key_str[start..start + end_offset + end_pkcs8.len()];
-            println!("aws-iot-sdk: PKCS8 key detected, attempting to normalize encoding");
-            {
-                use p256::pkcs8::{DecodePrivateKey, EncodePrivateKey};
-                if let Ok(key) = p256::SecretKey::from_pkcs8_pem(pkcs8_block) {
-                    if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
-                        println!("aws-iot-sdk: PKCS8 key normalized (P-256)");
-                        return doc.as_bytes().to_vec();
-                    }
-                }
+        let end_offset = key_str[start..].find(end_pkcs8).ok_or_else(|| {
+            error::AWSIoTError::KeyNormalizationError(
+                "PKCS8 PEM has BEGIN marker but no END marker".into(),
+            )
+        })?;
+        let pkcs8_block = &key_str[start..start + end_offset + end_pkcs8.len()];
+        {
+            use p256::pkcs8::{DecodePrivateKey, EncodePrivateKey};
+            if let Ok(key) = p256::SecretKey::from_pkcs8_pem(pkcs8_block) {
+                return key
+                    .to_pkcs8_pem(Default::default())
+                    .map(|doc| doc.as_bytes().to_vec())
+                    .map_err(|e| {
+                        error::AWSIoTError::KeyNormalizationError(format!(
+                            "failed to re-encode PKCS8 P-256 key: {e}"
+                        ))
+                    });
             }
-            {
-                use p384::pkcs8::{DecodePrivateKey, EncodePrivateKey};
-                if let Ok(key) = p384::SecretKey::from_pkcs8_pem(pkcs8_block) {
-                    if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
-                        println!("aws-iot-sdk: PKCS8 key normalized (P-384)");
-                        return doc.as_bytes().to_vec();
-                    }
-                }
-            }
-            // PKCS8 parsing failed — the PEM header might be lying and the DER
-            // content could actually be SEC1 (raw EC key).  Decode the base64
-            // payload and try SEC1 DER parsing as a last resort.
-            println!("aws-iot-sdk: PKCS8 parsing failed, trying SEC1 DER fallback");
-            let base64_body: String = pkcs8_block
-                .lines()
-                .filter(|l| !l.starts_with("-----"))
-                .collect();
-            use base64::Engine;
-            if let Ok(der) = base64::engine::general_purpose::STANDARD.decode(base64_body.trim()) {
-                if let Ok(key) = p256::SecretKey::from_sec1_der(&der) {
-                    use p256::pkcs8::EncodePrivateKey;
-                    if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
-                        println!("aws-iot-sdk: mislabeled SEC1 key converted to PKCS8 (P-256)");
-                        return doc.as_bytes().to_vec();
-                    }
-                }
-                if let Ok(key) = p384::SecretKey::from_sec1_der(&der) {
-                    use p384::pkcs8::EncodePrivateKey;
-                    if let Ok(doc) = key.to_pkcs8_pem(Default::default()) {
-                        println!("aws-iot-sdk: mislabeled SEC1 key converted to PKCS8 (P-384)");
-                        return doc.as_bytes().to_vec();
-                    }
-                }
-            }
-            println!("aws-iot-sdk: PKCS8 key is not P-256/P-384 EC (likely RSA), passing through");
         }
+        {
+            use p384::pkcs8::{DecodePrivateKey, EncodePrivateKey};
+            if let Ok(key) = p384::SecretKey::from_pkcs8_pem(pkcs8_block) {
+                return key
+                    .to_pkcs8_pem(Default::default())
+                    .map(|doc| doc.as_bytes().to_vec())
+                    .map_err(|e| {
+                        error::AWSIoTError::KeyNormalizationError(format!(
+                            "failed to re-encode PKCS8 P-384 key: {e}"
+                        ))
+                    });
+            }
+        }
+        // PKCS8 parsing failed — the PEM header might be lying and the DER
+        // content could actually be SEC1 (raw EC key).  Decode the base64
+        // payload and try SEC1 DER parsing as a last resort.
+        let base64_body: String = pkcs8_block
+            .lines()
+            .filter(|l| !l.starts_with("-----"))
+            .collect();
+        use base64::Engine;
+        let der = base64::engine::general_purpose::STANDARD
+            .decode(base64_body.trim())
+            .map_err(|e| {
+                error::AWSIoTError::KeyNormalizationError(format!(
+                    "PKCS8 PEM contains invalid base64: {e}"
+                ))
+            })?;
+        if let Ok(key) = p256::SecretKey::from_sec1_der(&der) {
+            use p256::pkcs8::EncodePrivateKey;
+            return key
+                .to_pkcs8_pem(Default::default())
+                .map(|doc| doc.as_bytes().to_vec())
+                .map_err(|e| {
+                    error::AWSIoTError::KeyNormalizationError(format!(
+                        "failed to re-encode mislabeled SEC1 P-256 key as PKCS8: {e}"
+                    ))
+                });
+        }
+        if let Ok(key) = p384::SecretKey::from_sec1_der(&der) {
+            use p384::pkcs8::EncodePrivateKey;
+            return key
+                .to_pkcs8_pem(Default::default())
+                .map(|doc| doc.as_bytes().to_vec())
+                .map_err(|e| {
+                    error::AWSIoTError::KeyNormalizationError(format!(
+                        "failed to re-encode mislabeled SEC1 P-384 key as PKCS8: {e}"
+                    ))
+                });
+        }
+        // Not an EC key we recognize — pass through unchanged (likely RSA or Ed25519).
+        return Ok(key_pem);
     }
 
-    key_pem
+    // No recognized PEM header — pass through unchanged (e.g. RSA PRIVATE KEY).
+    Ok(key_pem)
 }
 
 fn set_overrides(settings: AWSIoTSettings) -> MqttOptions {
@@ -209,7 +244,7 @@ pub(crate) async fn get_mqtt_options_async(
     let transport = (!transport_overrided).then_some({
         let ca = read(&settings.ca_path).await?;
         let client_cert = read(&settings.client_cert_path).await?;
-        let client_key = normalize_key(read(&settings.client_key_path).await?);
+        let client_key = normalize_key(read(&settings.client_key_path).await?)?;
 
         Transport::Tls(TlsConfiguration::Simple {
             ca,
@@ -240,7 +275,7 @@ pub(crate) fn get_mqtt_options(
     let transport = (!transport_overrided).then_some({
         let ca = read(&settings.ca_path)?;
         let client_cert = read(&settings.client_cert_path)?;
-        let client_key = normalize_key(read(&settings.client_key_path)?);
+        let client_key = normalize_key(read(&settings.client_key_path)?)?;
 
         Transport::Tls(TlsConfiguration::Simple {
             ca,


### PR DESCRIPTION
Some AWS IoT provisioning tools emit EC keys in SEC1 format or with                                                                                                                                              
non-standard PKCS8 encodings (e.g. explicit curve params instead of                                                                                                                                              
named OIDs) that rustls rejects. normalize_key now converts SEC1 and                                                                                                                                             
malformed PKCS8 EC keys (P-256, P-384) into canonical PKCS8 PEM                                                                                                                                                  
before passing them to the TLS stack.
                                                                                                                                                                                                                   
Key normalization returns Result with a new KeyNormalizationError                                                                                                                                                
variant instead of silently falling through on malformed keys,
callers get a clear error at load time rather than a confusing TLS                                                                                                                                               
handshake failure.

After updating to 0.7.0 I saw some machines with EC keys failing. This should fix it.